### PR TITLE
Fix for String not found error in Unix/Linux

### DIFF
--- a/ProcessList.phpclass
+++ b/ProcessList.phpclass
@@ -217,7 +217,7 @@ class  ProcessList		implements	\ArrayAccess, \Countable, \IteratorAggregate
 		for  ( $i = 1 ; $i  <  $count ; $i ++ )
 		   {
 			$line		=  trim ( $output [$i] ) ;
-			$columns	=  String::SplitFields ( $line, 6 ) ;
+			$columns 	=  preg_split('/ +/', $line);
 			$process	=  new  Process ( $columns [7], null, $this -> IsWindows ) ;
 
 			if  ( preg_match ( '/\d+:\d+/', $columns [4] ) )


### PR DESCRIPTION
Fix for below error
```
PHP Fatal error:  Uncaught Error: Class 'String' not found in /home/vagrant/Code/php-boilerplate/ProcessList.phpclass:220
Stack trace:
#0 /home/vagrant/Code/process/ProcessList.phpclass(128): ProcessList->UnixPs()
#1 /home/vagrant/Code/process/ProcessList.phpclass(50): ProcessList->Refresh()
#2 /home/vagrant/Code/process/process.php(20): ProcessList->__construct()
#3 {main}
  thrown in /home/vagrant/Code/process/ProcessList.phpclass on line 220
```